### PR TITLE
Invert icons in dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -127,3 +127,9 @@ p.a:before {
 .will::before {
 	content:url('will.svg');
 }
+
+@media (prefers-color-scheme: dark) {
+  .reckoning, .investigators, .lore, .influence, .observation, .strength, .will {
+    filter: invert(100%);
+  }
+}


### PR DESCRIPTION
The background of the page is dark so icons are barely visible. To fix this, apply a filter when in dark mode to invert icons.